### PR TITLE
Don't show videos in multiple image picker iOS

### DIFF
--- a/src/SkyDrop.iOS/Common/ImageSelectionHelper.cs
+++ b/src/SkyDrop.iOS/Common/ImageSelectionHelper.cs
@@ -128,7 +128,7 @@ namespace SkyDrop.iOS.Common
                 MinimumInteritemSpacing = 2.0f,
                 ShowCameraButton = false,
                 AutoSelectCameraImages = false,
-                MediaTypes = new[] { PHAssetMediaType.Image, PHAssetMediaType.Video, PHAssetMediaType.Audio, PHAssetMediaType.Unknown },
+                MediaTypes = new[] { PHAssetMediaType.Image },
 
                 NavigationBarBackgroundColor = UIColor.White,
                 NavigationBarTextColor = UIColor.Black,
@@ -139,7 +139,6 @@ namespace SkyDrop.iOS.Common
         private static async Task<bool> CheckPhotoPermission()
         {
             var status = ALAssetsLibrary.AuthorizationStatus;
-
             if (status == ALAuthorizationStatus.Denied)
             {
                 var alert = UIAlertController.Create(Strings.NoPhotoAccessTitle, Strings.NoPhotoAccessMessage, UIAlertControllerStyle.Alert);


### PR DESCRIPTION
iOS image picker was showing videos, but when selected, the filesystem just gave us a .jpeg screenshot

So I disabled videos and other types, now only images can be selected from this view

Videos can still be selected one at a time with "Select Video"