### PR TITLE
Fix android nav bar showing wrong color

### DIFF
--- a/src/SkyDrop.Droid/Resources/values/styles.xml
+++ b/src/SkyDrop.Droid/Resources/values/styles.xml
@@ -11,6 +11,7 @@
         <item name="colorControlActivated">@color/lightGrey</item><!--for ProgressBar-->
         <item name="colorControlHighlight">@color/lightGrey</item>
         <item name="windowActionModeOverlay">false</item>
+        <item name="android:navigationBarColor">@color/darkGrey</item>
     </style>
 
     <!-- Default App theme applied if no resource style overrides for specific API level -->


### PR DESCRIPTION
Now it does not show the wrong color
![Screenshot_20220819-234506](https://user-images.githubusercontent.com/42177014/185716980-1060c7ce-a09c-4a20-8751-700f44943327.jpg)
