### PR TITLE
Fix DropView title label not resizing iOS

### DIFF
--- a/src/SkyDrop.iOS/Views/Drop/DropView.cs
+++ b/src/SkyDrop.iOS/Views/Drop/DropView.cs
@@ -220,6 +220,7 @@ namespace SkyDrop.iOS.Views.Drop
                 LineBreakMode = UILineBreakMode.MiddleTruncation,
 
                 //makes label auto resize after text changes
+                Bounds = new CGRect(0, 0, UIScreen.MainScreen.Bounds.Width, 48),
                 TranslatesAutoresizingMaskIntoConstraints = true
             };
 


### PR DESCRIPTION
Fix title obscured bug as seen in this screenshot:

![306392810_1109026763033283_2001541601190984719_n](https://user-images.githubusercontent.com/42177014/189771274-a71506b5-1ddc-4857-b305-065b93322f3a.jpeg)
