### PR TITLE
Fix unable to save zip file bug

### DIFF
--- a/src/SkyDrop.Core/Services/EncryptionService.cs
+++ b/src/SkyDrop.Core/Services/EncryptionService.cs
@@ -107,7 +107,7 @@ namespace SkyDrop.Core.Services
             return Convert.ToBase64String(publicKeyWithId);
         }
 
-        public Task<string> EncodeFileFor(string filePath, List<Contact> recipients)
+        public Task<string> EncodeFileFor(string filePath, List<Contact> recipients, bool isSkyDropArchive)
         {
             return Task.Run(() =>
             {
@@ -138,7 +138,7 @@ namespace SkyDrop.Core.Services
                 var encryptedFileWithMetaData = Util.Combine(metaData, encryptedBytes);
 
                 //save the file
-                var randomFileName = GenerateEncryptedFileName(Path.GetFileName(filePath));
+                var randomFileName = GenerateEncryptedFileName(isSkyDropArchive);
                 var encryptedFilePath = Path.Combine(fileSystemService.CacheFolderPath, randomFileName);
                 File.WriteAllBytes(encryptedFilePath, encryptedFileWithMetaData);
 
@@ -444,16 +444,19 @@ namespace SkyDrop.Core.Services
             return (fileName, file);
         }
 
-        private string GenerateEncryptedFileName(string originalFileName)
+        private string GenerateEncryptedFileName(bool isSkyDropArchive)
         {
             //generate name from Guid, without dashes
             var name = new StringBuilder(Guid.NewGuid().ToString("N"));
 
-            if (Util.GetFileCategory(originalFileName) == FileCategory.Zip)
+            if (isSkyDropArchive)
             {
                 //add zi signature to identify skydrop encrypted zip files
                 name[15] = 'z';
                 name[16] = 'i';
+
+                //note this signature is only used for archives made with skydrop
+                //because we currently only support unzipping flat zip archives that do not contain directories
             }
             else
             {
@@ -477,7 +480,7 @@ namespace SkyDrop.Core.Services
 
         (AddContactResult result, Guid newContactId, string existingContactSavedName) AddPublicKey(string publicKeyEncoded);
 
-        Task<string> EncodeFileFor(string filePath, List<Contact> recipients);
+        Task<string> EncodeFileFor(string filePath, List<Contact> recipients, bool isSkyDropArchive);
 
         Task<string> DecodeFile(string filePath);
 

--- a/src/SkyDrop.Core/Utility/Util.cs
+++ b/src/SkyDrop.Core/Utility/Util.cs
@@ -219,7 +219,7 @@ namespace SkyDrop.Core.Utility
 
         public static bool IsEncryptedZipFile(this string filename)
         {
-            if (filename.Length != 32) //length of a guid without dashes
+            if (filename?.Length != 32) //length of a guid without dashes
                 return false;
 
             var ziSignatureExists = filename[15] == 'z' && filename[16] == 'i'; //is encrypted zip file

--- a/src/SkyDrop.Core/ViewModels/DropViewModel.cs
+++ b/src/SkyDrop.Core/ViewModels/DropViewModel.cs
@@ -272,7 +272,8 @@ namespace SkyDrop.Core.ViewModels.Main
             {
                 IsUploading = true;
 
-                if (StagedFiles.Count() > 2) //file and add more files button
+                var isSkyDropArchive = StagedFiles.Count() > 2; //file and add more files button
+                if (isSkyDropArchive) 
                     FileToUpload = MakeZipFile();
                 else
                     FileToUpload = StagedFiles.First().SkyFile;
@@ -289,7 +290,7 @@ namespace SkyDrop.Core.ViewModels.Main
                 if (encryptionContact != null)
                 {
                     IsEncrypting = true;
-                    var encryptedPath = await encryptionService.EncodeFileFor(FileToUpload.FullFilePath, new List<Contact> { encryptionContact });
+                    var encryptedPath = await encryptionService.EncodeFileFor(FileToUpload.FullFilePath, new List<Contact> { encryptionContact }, isSkyDropArchive);
 
                     //we use a second property for the encrypted path so that we can preserve the original path, in case file needs to be encrypted again (after changing recipients)
                     FileToUpload.EncryptedFilePath = encryptedPath;


### PR DESCRIPTION
This bug was causing non-skydrop archives (external zip files) to not be save-able