### PR TITLE
Bugfix: save file button "Filename cannot be null"

### DIFF
--- a/src/SkyDrop.Core/Services/ApiService.cs
+++ b/src/SkyDrop.Core/Services/ApiService.cs
@@ -100,6 +100,9 @@ namespace SkyDrop.Core.Services
             //download
             var httpClient = httpClientFactory.GetSkyDropHttpClientInstance(SkynetPortal.SelectedPortal);
             var response = await httpClient.GetAsync(url);
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                throw new Exception("Unauthorized. Check your API key is set correctly in the Portals screen.");
+
             if (!response.IsSuccessStatusCode)
                 throw new Exception(response.StatusCode.ToString());
             

--- a/src/SkyDrop.Core/Services/ApiService.cs
+++ b/src/SkyDrop.Core/Services/ApiService.cs
@@ -100,6 +100,8 @@ namespace SkyDrop.Core.Services
             //download
             var httpClient = httpClientFactory.GetSkyDropHttpClientInstance(SkynetPortal.SelectedPortal);
             var response = await httpClient.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+                throw new Exception(response.StatusCode.ToString());
             
             var fileName = GetFilenameFromResponse(response);
             if (fileName == null)

--- a/src/SkyDrop.Core/Services/ApiService.cs
+++ b/src/SkyDrop.Core/Services/ApiService.cs
@@ -27,6 +27,8 @@ namespace SkyDrop.Core.Services
         private readonly IUserDialogs userDialogs;
         private readonly IEncryptionService encryptionService;
 
+        private const string unauthorizedExceptionMessage = "Unauthorized. Check your API key is set correctly in the Portals screen.";
+
         public ApiService(ILog log,
             ISkyDropHttpClientFactory skyDropHttpClientFactory,
             ISingletonService singletonService,
@@ -101,7 +103,7 @@ namespace SkyDrop.Core.Services
             var httpClient = httpClientFactory.GetSkyDropHttpClientInstance(SkynetPortal.SelectedPortal);
             var response = await httpClient.GetAsync(url);
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
-                throw new Exception("Unauthorized. Check your API key is set correctly in the Portals screen.");
+                throw new Exception(unauthorizedExceptionMessage);
 
             if (!response.IsSuccessStatusCode)
                 throw new Exception(response.StatusCode.ToString());
@@ -132,6 +134,9 @@ namespace SkyDrop.Core.Services
         {
             var httpClient = httpClientFactory.GetSkyDropHttpClientInstance(SkynetPortal.SelectedPortal);
             var response = await httpClient.GetAsync(url);
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                throw new Exception(unauthorizedExceptionMessage);
+
             response.EnsureSuccessStatusCode();
             var data = await response.Content.ReadAsStreamAsync();
             var fileName = GetFilenameFromResponse(response);

--- a/src/SkyDrop.Core/ViewModels/DropViewModel.cs
+++ b/src/SkyDrop.Core/ViewModels/DropViewModel.cs
@@ -938,7 +938,7 @@ namespace SkyDrop.Core.ViewModels.Main
             }
             catch(Exception e)
             {
-                userDialogs.Toast(e.Message);
+                userDialogs.Toast(e.Message, TimeSpan.FromSeconds(4));
             }
             finally
             {

--- a/src/SkyDrop.Core/ViewModels/FilesViewModel.cs
+++ b/src/SkyDrop.Core/ViewModels/FilesViewModel.cs
@@ -554,7 +554,7 @@ namespace SkyDrop.Core.ViewModels.Main
             catch (Exception e)
             {
                 log.Exception(e);
-                userDialogs.Toast(e.Message);
+                userDialogs.Toast(e.Message, TimeSpan.FromSeconds(4));
             }
             finally
             {

--- a/src/SkyDrop.iOS/SkyDrop.iOS.csproj
+++ b/src/SkyDrop.iOS/SkyDrop.iOS.csproj
@@ -28,6 +28,8 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
 <OptimizePNGs>false</OptimizePNGs>
+<CodesignProvision></CodesignProvision>
+<CodesignEntitlements>..\..\..\XamarinFormsPayments\PayPalTesting\PayPalTesting\PayPalTesting.iOS\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
Save file was not really broken. It just looked broken because of a bad error message. 

The file download now fails when the user has not set an API key.  So here I have improved the error message.

I also noticed SecureStorage was throwing some exceptions on iOS when trying to set the API key, which was fixed by referencing the Entitlements.plist file in the iOS project file